### PR TITLE
Show discussion title in tooltip

### DIFF
--- a/lib/pages/DiscussionPage.dart
+++ b/lib/pages/DiscussionPage.dart
@@ -100,7 +100,12 @@ class _DiscussionPageState extends State<DiscussionPage> {
           middle: Container(
               alignment: Alignment.center,
               width: MediaQuery.of(context).size.width - 120,
-              child: Text(title, style: TextStyle(color: colors.text), overflow: TextOverflow.ellipsis))),
+              child: Tooltip(
+                  message: title,
+                  child: Text(title.replaceAll('', '\u{200B}'), style: TextStyle(color: colors.text), overflow: TextOverflow.ellipsis),
+                  padding: EdgeInsets.all(8.0), // needed until https://github.com/flutter/flutter/issues/86170 is fixed
+                  margin: EdgeInsets.all(8.0),
+              ))),
       child: body,
     );
   }
@@ -111,7 +116,7 @@ class _DiscussionPageState extends State<DiscussionPage> {
     SyntaxHighlighter.languageContext = discussionResponse.discussion.name;
 
     return _pageScaffold(
-        title: discussionResponse.discussion.name.replaceAll('', '\u{200B}'),
+        title: discussionResponse.discussion.name,
         body: Stack(
           children: [
             NotificationListener<PostDeleteFailNotification>(


### PR DESCRIPTION
This is useful for discussions with long name, that changes from time to time and that may contain useful information about current topic.

Screenshot:
![obrazek](https://user-images.githubusercontent.com/4223239/148837879-6d8fcc14-b6eb-4b71-b8ae-35b4e3e1809a.png)



