### PR TITLE
Correctly report Android OS version

### DIFF
--- a/lib/libs/DeviceInfo.dart
+++ b/lib/libs/DeviceInfo.dart
@@ -20,8 +20,8 @@ class DeviceInfo {
   }
 
   DeviceInfo.adroid(AndroidDeviceInfo info) {
-    systemName = info.device;
-    systemVersion = info.version.codename;
+    systemName = 'Android';
+    systemVersion = '${info.version.release} (SDK ${info.version.sdkInt})';
     localizedModel = info.model;
   }
 }


### PR DESCRIPTION
Previous implementation reported wrongly _device_ codename + REL (as release version of OS)