### PR TITLE
Disable canLaunchUrl check for https/http schemas. This fixes #380

### DIFF
--- a/lib/theme/T.dart
+++ b/lib/theme/T.dart
@@ -55,9 +55,12 @@ class T {
     try {
       var encodedUri = Uri.parse(link);
 
-      var canLaunch = await canLaunchUrl(encodedUri);
-      if (!canLaunch) {
-        throw ('Cannot launch url: $link');
+      // canLaunchUrl returns false on Android, if app handling the http(s) url is installed, even though launchUrl works afterwards
+      if (encodedUri.scheme != 'https' && encodedUri.scheme != 'http') {
+        var canLaunch = await canLaunchUrl(encodedUri);
+        if (!canLaunch) {
+          throw ('Cannot launch url: $link');
+        }
       }
 
       var status = await launchUrl(encodedUri, mode: mode.original);


### PR DESCRIPTION
It provides incorrect indication of real capability to open the url

From the documentation: https://pub.dev/packages/url_launcher#checking-supported-schemes

> However, canLaunchUrl can return false even if launchUrl would work in some circumstances (in web applications,
> on mobile without the necessary configuration as described above, etc.), so in cases where you can provide
> fallback behavior it is better to use launchUrl directly and handle failure.