### PR TITLE
Fix wrapping markdown into <p> elements

### DIFF
--- a/lib/features/message/presentation/message_screen.dart
+++ b/lib/features/message/presentation/message_screen.dart
@@ -342,6 +342,7 @@ class _MessageScreenState extends State<MessageScreen> {
                                   String message = state.useMarkdown
                                       ? md.markdownToHtml(
                                           _messageController.text,
+                                          inlineOnly: true,
                                           inlineSyntaxes: [
                                             md.DelimiterSyntax('§+', tags: [md.DelimiterTag('span class="spoiler"', 1)], requiresDelimiterRun: true),
                                             md.AutolinkExtensionSyntax()


### PR DESCRIPTION
`<p>` renders with unexpected padding on web and is also broken in replies #474

After this fix, default paragraph parsing is disabled, but rest seems to work as expcted