### PR TITLE
Don't change image format while resizing

### DIFF
--- a/lib/controllers/ApiProvider.dart
+++ b/lib/controllers/ApiProvider.dart
@@ -11,7 +11,7 @@ import 'package:image/image.dart' as img;
 Uint8List _resizeIsolate(({Uint8List bytes, int maxWidth, String extension}) params) {
   final decoded = img.decodeImage(params.bytes);
   if (decoded == null || decoded.width <= params.maxWidth) return params.bytes;
-  final resized = img.copyResize(decoded, width: params.maxWidth);
+  final resized = img.copyResize(decoded, width: params.maxWidth, interpolation: img.Interpolation.cubic);
   return img.encodeNamedImage('file.${params.extension}', resized) ?? img.encodeJpg(resized);
 }
 

--- a/lib/controllers/ApiProvider.dart
+++ b/lib/controllers/ApiProvider.dart
@@ -8,11 +8,11 @@ import 'package:fyx/model/MainRepository.dart';
 import 'package:fyx/theme/L.dart';
 import 'package:image/image.dart' as img;
 
-Uint8List _resizeIsolate(({Uint8List bytes, int maxWidth}) params) {
+Uint8List _resizeIsolate(({Uint8List bytes, int maxWidth, String extension}) params) {
   final decoded = img.decodeImage(params.bytes);
   if (decoded == null || decoded.width <= params.maxWidth) return params.bytes;
   final resized = img.copyResize(decoded, width: params.maxWidth);
-  return Uint8List.fromList(img.encodeJpg(resized));
+  return img.encodeNamedImage('file.${params.extension}', resized) ?? img.encodeJpg(resized);
 }
 
 class ApiProvider implements IApiProvider {
@@ -235,7 +235,7 @@ class ApiProvider implements IApiProvider {
 
   Future<Response> uploadFile(Attachment attachment, {int id = 0}) async {
     final needResize = attachment.mediaType.type == 'image' && [ImageQuality.sd, ImageQuality.md].contains(attachment.quality);
-    final bytes = needResize ? await compute(_resizeIsolate, (bytes: attachment.bytes, maxWidth: attachment.width)) : attachment.bytes;
+    final bytes = needResize ? await compute(_resizeIsolate, (bytes: attachment.bytes, maxWidth: attachment.width, extension: attachment.extension)) : attachment.bytes;
     FormData fileData = FormData.fromMap({
       'file': MultipartFile.fromBytes(bytes, filename: attachment.filename, contentType: attachment.mediaType),
       'file_type': id == 0 ? 'mail_attachment' : 'discussion_attachment',

--- a/lib/features/message/presentation/message_screen.dart
+++ b/lib/features/message/presentation/message_screen.dart
@@ -435,10 +435,13 @@ class _MessageScreenState extends State<MessageScreen> {
                                                         FocusScope.of(context).unfocus();
                                                         final imageBytes = await Pasteboard.image;
                                                         if (imageBytes != null) {
+                                                          final detectedMime = lookupMimeType('', headerBytes: imageBytes.sublist(0, 12)) ?? 'image/jpeg';
+                                                          final mimeParts = detectedMime.split('/');
+                                                          final subtype = mimeParts.length > 1 ? mimeParts[1] : 'jpeg';
                                                           viewModel.addAttachment(new Attachment(
-                                                            filename: 'pasteboard_image.${DateTime.now().millisecondsSinceEpoch}.jpg',
-                                                            extension: 'jpg',
-                                                            mediaType: MediaType('image', 'jpeg'),
+                                                            filename: 'pasteboard_image.${DateTime.now().millisecondsSinceEpoch}.$subtype',
+                                                            extension: subtype,
+                                                            mediaType: MediaType('image', subtype),
                                                             bytes: imageBytes,
                                                           ));
                                                         }

--- a/lib/features/message/presentation/message_screen.dart
+++ b/lib/features/message/presentation/message_screen.dart
@@ -435,7 +435,7 @@ class _MessageScreenState extends State<MessageScreen> {
                                                         FocusScope.of(context).unfocus();
                                                         final imageBytes = await Pasteboard.image;
                                                         if (imageBytes != null) {
-                                                          final detectedMime = lookupMimeType('', headerBytes: imageBytes.sublist(0, 12)) ?? 'image/jpeg';
+                                                          final detectedMime = lookupMimeType('', headerBytes: imageBytes.sublist(0, imageBytes.length < 12 ? imageBytes.length : 12)) ?? 'image/jpeg';
                                                           final mimeParts = detectedMime.split('/');
                                                           final subtype = mimeParts.length > 1 ? mimeParts[1] : 'jpeg';
                                                           viewModel.addAttachment(new Attachment(


### PR DESCRIPTION
Fixes #162 

Zároveň jsme tam přidal kubickou interpolaci místo defaultní nearest neigbour, která má fakt odporný výsledky :)

A teda bohužel při tom pastování ze schránky to v praxi na ANdroidu nepomůže, i když si dám do schránky png obrázek z galerie, tak Android pastne jpg. Ale Třeba bude aspoň iOS chytřejší.

A má to teda limitaci na straně serveru. Pokud je obrázek větší než mne neznámý limit, Nyx ho sám zmenší a uloží jako jpg, viz https://nyx.cz/discussion/1/id/58795149 9v tuto chvílí bez reakce od Nyxe)